### PR TITLE
Ensure SoC step returns generated thought and interrupt info

### DIFF
--- a/app/soc.py
+++ b/app/soc.py
@@ -132,6 +132,8 @@ class SoCEngine:
                     Scraper().execute(ScrapePlan(question=q, seeds=seeds, max_pages=_settings.SCRAPER_MAX_PAGES,
                                                  allow_domains=_settings.allowlist()))
 
+        return th, stored, interrupts
+
 
 async def run_soc_loop(engine: SoCEngine, get_stimuli_cb, stop_evt: asyncio.Event) -> None:
     cadence = settings.SOC_CADENCE_SECONDS


### PR DESCRIPTION
## Summary
- Return the generated thought, storage decision, and interrupts from `SoCEngine.step`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3bbaad59483329664928eb5fc27a8