### PR TITLE
Fix stub LLM snippet extraction and ensure tests import package

### DIFF
--- a/app/providers/stubs.py
+++ b/app/providers/stubs.py
@@ -42,9 +42,9 @@ class StubLLM(LLMProvider):
         m = re.search(r"Stimuli:\s*(.+)", prompt, flags=re.DOTALL)
         stimuli = (m.group(1) if m else "").strip().splitlines()
         snippet = ""
-        for ln in stimuli[::-1]:
+        for ln in reversed(stimuli):
             ln = ln.strip()
-            if ln:
+            if ln and ":" in ln:
                 snippet = re.sub(r"^\w+:\s*", "", ln)  # drop "cli:" etc.
                 break
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parent.parent
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))

--- a/tests/test_socCycle.py
+++ b/tests/test_socCycle.py
@@ -30,3 +30,5 @@ def test_soc_cycle_and_store_and_interrupt():
     assert isinstance(stored, bool)
     # if it's a question, we should get an interrupt id
     assert isinstance(inter, list)
+    # The generated thought should reference the stimulus content
+    assert "guideline" in thought.content.lower()


### PR DESCRIPTION
## Summary
- Fix StubLLM to ignore non-stimulus lines so generated thoughts reflect latest input
- Verify SoC cycle returns thought referencing stimulus
- Add tests `conftest` to ensure `app` package is importable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3bd8d5fcc8332a600cdce14e4204c