### PR TITLE
Return SoC thought in stimuli responses

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -108,8 +108,15 @@ async def ingest(stimuli: List[Dict[str, Any]], _: None = Depends(_auth_dep)) ->
         upsert_memory(mem)
     # Trigger one SoC step
     SOC_CYCLE_COUNTER.inc()
-    SOC.step([Stimulus(**s) for s in stimuli])
-    return {"ok": True}
+    thought, stored, interrupts = SOC.step([Stimulus(**s) for s in stimuli])
+    wm_view = [t.model_dump() for t in WM.view(5)]
+    return {
+        "ok": True,
+        "thought": thought.model_dump(),
+        "stored": stored,
+        "interrupts": interrupts,
+        "wm": wm_view,
+    }
 
 
 @app.get("/wm")

--- a/app/providers/stubs.py
+++ b/app/providers/stubs.py
@@ -42,9 +42,9 @@ class StubLLM(LLMProvider):
         m = re.search(r"Stimuli:\s*(.+)", prompt, flags=re.DOTALL)
         stimuli = (m.group(1) if m else "").strip().splitlines()
         snippet = ""
-        for ln in stimuli[::-1]:
+        for ln in reversed(stimuli):
             ln = ln.strip()
-            if ln:
+            if ln and ":" in ln:
                 snippet = re.sub(r"^\w+:\s*", "", ln)  # drop "cli:" etc.
                 break
 

--- a/cli.py
+++ b/cli.py
@@ -31,7 +31,12 @@ def ingest(text: str, source: str = "cli") -> None:
         }
     ]
     r = requests.post(f"{API}/stimuli", json=payload, timeout=10)
-    typer.echo(r.json())
+    data = r.json()
+    thought = data.get("thought", {}).get("content")
+    if thought:
+        typer.echo(f"Ghost: {thought}")
+    else:
+        typer.echo(json.dumps(data, indent=2))
 
 
 @app.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parent.parent
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))

--- a/tests/test_api_feedback.py
+++ b/tests/test_api_feedback.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from app.api import app
+
+
+def test_ingest_returns_thought_and_wm():
+    client = TestClient(app)
+    stimulus = {
+        "id": "stim-test",
+        "source": "unit-test",
+        "content": "Study linear algebra",
+        "metadata": {},
+        "ts": 0,
+    }
+    resp = client.post("/stimuli", json=[stimulus])
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    thought = data.get("thought", {})
+    assert "content" in thought
+    # thought references the stimulus
+    assert "linear algebra" in thought["content"].lower()
+    # working memory last entry matches thought content
+    assert data["wm"][-1]["content"] == thought["content"]
+    assert isinstance(data.get("stored"), bool)

--- a/tests/test_socCycle.py
+++ b/tests/test_socCycle.py
@@ -30,3 +30,5 @@ def test_soc_cycle_and_store_and_interrupt():
     assert isinstance(stored, bool)
     # if it's a question, we should get an interrupt id
     assert isinstance(inter, list)
+    # The generated thought should reference the stimulus content
+    assert "guideline" in thought.content.lower()


### PR DESCRIPTION
## Summary
- Stimuli ingestion endpoint now returns the generated thought, storage decision, interrupts, and a snapshot of working memory for clearer internal flow and feedback.
- CLI `ingest` command surfaces the latest thought to the user for immediate confirmation of processed input.
- Added test verifying the API echoes a thought referencing the submitted stimulus and updates working memory.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd8d5fcc8332a600cdce14e4204c