### PR TITLE
Use docker compose in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ soc:
 	python -c "from app.soc import run_soc_main; import asyncio; asyncio.run(run_soc_main())"
 
 up:
-	docker-compose up --build
+        docker compose up --build
 
 down:
-	docker-compose down
+        docker compose down


### PR DESCRIPTION
## Summary
- Use `docker compose` instead of deprecated `docker-compose`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd95c3488332af97cc215bd380ed