### PR TITLE
Support docker-compose fallback in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ PYTHON := python3
 POETRY := poetry
 PKG := ghost
 
+DOCKER := $(shell command -v docker 2>/dev/null)
+COMPOSE := $(if $(DOCKER),docker compose,docker-compose)
+
 .PHONY: venv install lint type test cov fmt up down api cli soc
 
 venv:
@@ -39,7 +42,7 @@ soc:
 	python -c "from app.soc import run_soc_main; import asyncio; asyncio.run(run_soc_main())"
 
 up:
-	docker-compose up --build
+	$(COMPOSE) up --build
 
 down:
-	docker-compose down
+	$(COMPOSE) down


### PR DESCRIPTION
## Summary
- Detect whether the Docker CLI is available and fall back to legacy `docker-compose`
- Use the detected compose command for `up` and `down` targets

## Testing
- `pytest -q`
- `make up` *(fails: `/bin/bash: line 1: docker-compose: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68a4dd95c3488332af97cc215bd380ed