### PR TITLE
Define docker compose command for `make up` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 PYTHON := python3
 POETRY := poetry
 PKG := ghost
+COMPOSE ?= docker compose
 
 .PHONY: venv install lint type test cov fmt up down api cli soc
 


### PR DESCRIPTION
## Summary
- set `COMPOSE` default to `docker compose` so `make up` works

## Testing
- `make install`
- `make lint` *(fails: ruff reported unused imports in tests/test_scraper.py, etc.)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e10ae0f0833288e349528ed7af1e