### PR TITLE
Specify package for editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
 faiss = ["faiss-cpu>=1.8,<2.0"]
 playwright = ["playwright>=1.47,<2.0"]
 
+[tool.setuptools]
+packages = ["app"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"


### PR DESCRIPTION
## Summary
- Explicitly set the `app` package in `pyproject.toml` to avoid setuptools discovering multiple top-level packages during editable installs.

## Testing
- `python3 -m pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e50a4cf48332a4645aed52aef3f8