### PR TITLE
Expose SoC thoughts and support sub-second cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ CLI
     ghost export               # export LTM as JSONL
 ```
 
+To observe the Stream of Consciousness loop directly for debugging, run:
+
+```bash
+    SOC_CADENCE_SECONDS=0.1 SOC_JITTER_SECONDS=0 python -m app.soc
+```
+This prints each generated micro-thought as JSON to stdout. Lower cadences such as
+`0.05` are supported if your system can keep up.
+
 ### Configuration (via .env or env vars)
 
 | Key                       |         Default | Description                                      |

--- a/app/api.py
+++ b/app/api.py
@@ -176,7 +176,7 @@ def set_user_available(available: bool, _: None = Depends(_auth_dep)) -> Any:
 
 @app.post("/config/soc_cadence")
 def set_soc_cadence(seconds: float, _: None = Depends(_auth_dep)) -> Any:
-    settings.SOC_CADENCE_SECONDS = max(0.1, float(seconds))
+    settings.SOC_CADENCE_SECONDS = max(0.01, float(seconds))
     return {"ok": True, "soc_cadence": settings.SOC_CADENCE_SECONDS}
 
 @app.get("/interrupts")


### PR DESCRIPTION
## Summary
- log each Stream-of-Consciousness micro-thought as JSON so loops are visible
- allow SOC_CADENCE_SECONDS below one second via API and loop timing
- document how to run SoC debug loop

## Testing
- `/root/.pyenv/versions/3.11.12/bin/python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a502bdfa248332843d00d2e908ff71