### PR TITLE
Add local Ollama LLM provider with llama.cpp fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ LLMProvider.generate(system: str, prompt: str, max_tokens: int, **kw) -> str
 EmbeddingsProvider.embed(texts: List[str]) -> List[List[float]]
 ```
 
+#### Local LLM via Ollama
+
+```
+scripts/dev_setup_local_llm.sh    # install & pull default model
+export PROVIDER_LLM=ollama        # enable provider
+python -m app.soc                 # run with local model
+```
+
 ### Security & Privacy
 
 Robots-aware scraping (urllib.robotparser).

--- a/app/api.py
+++ b/app/api.py
@@ -15,7 +15,14 @@ from .schema import Stimulus
 from .settings import settings
 from .memory_working import WorkingMemory
 from .memory_longterm import keyword_search, vector_search, list_recent
-from .providers import StubLLM, StubEmbeddings, SystemClock, LLMProvider, EmbeddingsProvider, Clock
+from .providers import (
+    LLMProvider,
+    EmbeddingsProvider,
+    Clock,
+    StubEmbeddings,
+    SystemClock,
+    create_llm,
+)
 from .soc import SoCEngine, run_soc_loop
 from .attention import AttentionScheduler
 from .interrupts import InterruptManager
@@ -39,7 +46,7 @@ SOC_CYCLE_COUNTER = Counter("ghost_soc_cycles_total", "SoC cycles", registry=REG
 # Simple in-proc singletons
 WM = WorkingMemory()
 EMB: EmbeddingsProvider = StubEmbeddings()
-LLM: LLMProvider = StubLLM()
+LLM: LLMProvider = create_llm()
 CLOCK: Clock = SystemClock()
 INT = InterruptManager()
 ATTN = AttentionScheduler()

--- a/app/providers/__init__.py
+++ b/app/providers/__init__.py
@@ -2,5 +2,22 @@ from .llm_base import LLMProvider
 from .embeddings_base import EmbeddingsProvider
 from .clock import Clock
 from .stubs import StubLLM, StubEmbeddings, SystemClock
+from .ollama import OllamaProvider
+from ..settings import settings
 
-__all__ = ["LLMProvider", "EmbeddingsProvider", "Clock", "StubLLM", "StubEmbeddings", "SystemClock"]
+
+def create_llm() -> LLMProvider:
+    if settings.PROVIDER_LLM == "ollama":
+        return OllamaProvider()
+    return StubLLM()
+
+__all__ = [
+    "LLMProvider",
+    "EmbeddingsProvider",
+    "Clock",
+    "StubLLM",
+    "StubEmbeddings",
+    "SystemClock",
+    "OllamaProvider",
+    "create_llm",
+]

--- a/app/providers/ollama.py
+++ b/app/providers/ollama.py
@@ -1,0 +1,243 @@
+import json
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Generator, List, Optional, Union
+
+import httpx
+
+from .llm_base import LLMProvider
+from ..settings import settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODELS = [
+    "llama3.1:8b-instruct-q5_K_M",
+    "llama3.1:8b-instruct",
+    "mixtral:8x7b-instruct-q5_K_M",
+    "qwen2.5:7b-instruct-q5_K_M",
+]
+
+
+class OllamaProvider(LLMProvider):
+    def __init__(self) -> None:
+        self.base_url = "http://127.0.0.1:11434"
+        self.lcpp_url = settings.LLAMACPP_SERVER_URL
+        self.client = httpx.Client(timeout=httpx.Timeout(30.0, read=600.0))
+        self.ctx = settings.LLM_CTX
+        self.max_tokens = settings.LLM_MAX_TOKENS
+        self.temp = settings.LLM_TEMP
+        self.top_p = settings.LLM_TOP_P
+        self.top_k = settings.LLM_TOP_K
+        self.seed = settings.LLM_SEED
+        self.backend = "ollama"
+        self.model = self._select_model()
+
+        if not self._ollama_available():
+            if self.lcpp_url:
+                self.backend = "llama.cpp"
+            else:
+                raise RuntimeError(
+                    "No local LLM backend found. Start Ollama or set LLAMACPP_SERVER_URL."
+                )
+
+        if self.backend == "ollama" and not self._model_available(self.model):
+            self._pull_model(self.model)
+            if not self._model_available(self.model):
+                raise RuntimeError(
+                    f"Model '{self.model}' unavailable. Run scripts/dev_setup_local_llm.sh or `ollama pull {self.model}`."
+                )
+
+        logger.info(
+            "LLM backend=%s model=%s ctx=%s max_tokens=%s temp=%s seed=%s streaming=yes",
+            self.backend,
+            self.model,
+            self.ctx,
+            self.max_tokens,
+            self.temp,
+            self.seed,
+        )
+
+    # ------------------------------------------------------------------
+    def _select_model(self) -> str:
+        if settings.LLM_MODEL:
+            return settings.LLM_MODEL
+        try:
+            resp = httpx.get(f"{self.base_url}/api/tags", timeout=5.0)
+            tags = {m.get("name") for m in resp.json().get("models", [])}
+            for cand in DEFAULT_MODELS:
+                if cand in tags:
+                    return cand
+        except Exception:
+            pass
+        return DEFAULT_MODELS[0]
+
+    def _ollama_available(self) -> bool:
+        try:
+            self.client.get(f"{self.base_url}/api/tags")
+            return True
+        except Exception:
+            return False
+
+    def _model_available(self, model: str) -> bool:
+        try:
+            resp = self.client.get(f"{self.base_url}/api/tags")
+            tags = {m.get("name") for m in resp.json().get("models", [])}
+            return model in tags
+        except Exception:
+            return False
+
+    def _pull_model(self, model: str) -> None:
+        lock = Path("/tmp/ghost_ollama_pull.lock")
+        now = time.time()
+        if lock.exists() and now - lock.stat().st_mtime < 3600:
+            return
+        try:
+            lock.touch()
+            subprocess.run(["ollama", "pull", model], check=True)
+        except Exception as e:
+            logger.error("ollama pull failed: %s", e)
+        finally:
+            try:
+                lock.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _request_with_retries(self, method: str, url: str, *, stream: bool = False, **kwargs: Any):
+        for attempt in range(3):
+            try:
+                if stream:
+                    r = self.client.stream(method, url, **kwargs)
+                    if r.status_code >= 500:
+                        raise httpx.HTTPStatusError("server error", request=r.request, response=r)
+                    return r
+                r = self.client.request(method, url, **kwargs)
+            except httpx.HTTPError:
+                if attempt == 2:
+                    raise
+                time.sleep(2**attempt)
+                continue
+            if r.status_code >= 500:
+                if attempt == 2:
+                    r.raise_for_status()
+                time.sleep(2**attempt)
+                continue
+            return r
+        raise RuntimeError("unreachable")
+
+    # ------------------------------------------------------------------
+    def generate(
+        self,
+        system: str,
+        prompt: str,
+        max_tokens: int = 256,
+        **kwargs: Any,
+    ) -> Union[str, Generator[str, None, None]]:
+        stream: bool = kwargs.get("stream", False)
+        stop: Optional[List[str]] = kwargs.get("stop")
+
+        if len(system) + len(prompt) > self.ctx - 512:
+            logger.warning("Prompt length approaching context window")
+
+        if self.backend == "ollama":
+            return self._gen_ollama(system, prompt, max_tokens, stop, stream)
+        return self._gen_llamacpp(system, prompt, max_tokens, stop, stream)
+
+    # ------------------------------------------------------------------
+    def _gen_ollama(
+        self,
+        system: str,
+        prompt: str,
+        max_tokens: int,
+        stop: Optional[List[str]],
+        stream: bool,
+    ) -> Union[str, Generator[str, None, None]]:
+        url = f"{self.base_url}/api/chat"
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": prompt},
+            ],
+            "stream": stream,
+            "options": {
+                "temperature": self.temp,
+                "top_p": self.top_p,
+                "top_k": self.top_k,
+                "num_ctx": self.ctx,
+                "num_predict": max_tokens,
+            },
+        }
+        if stop:
+            payload["stop"] = stop
+        if self.seed is not None:
+            payload["options"]["seed"] = self.seed
+
+        if not stream:
+            resp = self._request_with_retries("POST", url, json=payload)
+            data = resp.json()
+            return data.get("message", {}).get("content", "")
+
+        def gen() -> Generator[str, None, None]:
+            with self._request_with_retries("POST", url, json=payload, stream=True) as r:
+                for line in r.iter_lines():
+                    if not line:
+                        continue
+                    data = json.loads(line)
+                    if data.get("done"):
+                        break
+                    chunk = data.get("message", {}).get("content")
+                    if chunk:
+                        yield chunk
+
+        return gen()
+
+    # ------------------------------------------------------------------
+    def _gen_llamacpp(
+        self,
+        system: str,
+        prompt: str,
+        max_tokens: int,
+        stop: Optional[List[str]],
+        stream: bool,
+    ) -> Union[str, Generator[str, None, None]]:
+        url = self.lcpp_url.rstrip("/") + "/v1/chat/completions"
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": self.temp,
+            "top_p": self.top_p,
+            "top_k": self.top_k,
+            "n_ctx": self.ctx,
+            "n_predict": max_tokens,
+            "stream": stream,
+        }
+        if stop:
+            payload["stop"] = stop
+        if self.seed is not None:
+            payload["seed"] = self.seed
+
+        if not stream:
+            resp = self._request_with_retries("POST", url, json=payload)
+            data = resp.json()
+            return data["choices"][0]["message"]["content"]
+
+        def gen() -> Generator[str, None, None]:
+            with self._request_with_retries("POST", url, json=payload, stream=True) as r:
+                for line in r.iter_lines():
+                    if not line:
+                        continue
+                    if line.startswith("data:"):
+                        line = line[len("data:"):].strip()
+                    if line.strip() == "[DONE]":
+                        break
+                    data = json.loads(line)
+                    delta = data["choices"][0]["delta"].get("content")
+                    if delta:
+                        yield delta
+
+        return gen()

--- a/app/settings.py
+++ b/app/settings.py
@@ -55,6 +55,16 @@ class Settings(BaseSettings):
     PROVIDER_EMBED: str = "stub"
     PROVIDER_CLOCK: str = "system"
 
+    # Local LLM configuration
+    LLM_MODEL: str | None = None
+    LLM_CTX: int = 8192
+    LLM_MAX_TOKENS: int = 512
+    LLM_TEMP: float = 0.7
+    LLM_TOP_P: float = 0.9
+    LLM_TOP_K: int = 40
+    LLM_SEED: int | None = None
+    LLAMACPP_SERVER_URL: str | None = None
+
     def allowlist(self) -> List[str]:
         s = self.ALLOWLIST_DOMAINS.strip()
         if s == "*":

--- a/app/soc.py
+++ b/app/soc.py
@@ -8,7 +8,14 @@ from typing import Dict, List, Optional, Tuple
 
 from .schema import Memory, Stimulus, Thought, now_ts
 from .settings import settings
-from .providers import LLMProvider, EmbeddingsProvider, Clock, StubLLM, StubEmbeddings, SystemClock
+from .providers import (
+    LLMProvider,
+    EmbeddingsProvider,
+    Clock,
+    StubEmbeddings,
+    SystemClock,
+    create_llm,
+)
 from .memory_working import WorkingMemory
 from .memory_longterm import upsert_memory, vector_search
 from .interrupts import InterruptManager
@@ -157,7 +164,7 @@ async def run_soc_loop(engine: SoCEngine, get_stimuli_cb, stop_evt: asyncio.Even
 
 async def run_soc_main() -> None:
     wm = WorkingMemory()
-    llm: LLMProvider = StubLLM()
+    llm: LLMProvider = create_llm()
     emb: EmbeddingsProvider = StubEmbeddings()
     clock: Clock = SystemClock()
     from .interrupts import InterruptManager

--- a/scripts/dev_setup_local_llm.sh
+++ b/scripts/dev_setup_local_llm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL=${LLM_MODEL:-llama3.1:8b-instruct-q5_K_M}
+
+if ! command -v ollama >/dev/null 2>&1; then
+  echo "Ollama not found. Installing..."
+  curl -fsSL https://ollama.ai/install.sh | sh
+fi
+
+echo "Pulling model $MODEL"
+ollama pull "$MODEL"
+
+echo "Done. Start the Ollama server with 'ollama serve' if not running."

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -1,0 +1,68 @@
+import os
+import httpx
+import pytest
+
+from app.providers.ollama import OllamaProvider
+from app.settings import settings
+
+
+def _backend_available() -> bool:
+    try:
+        httpx.get("http://127.0.0.1:11434/api/tags", timeout=1.0)
+        return True
+    except Exception:
+        url = settings.LLAMACPP_SERVER_URL or os.environ.get("LLAMACPP_SERVER_URL")
+        if not url:
+            return False
+        try:
+            httpx.get(url.rstrip("/") + "/v1/models", timeout=1.0)
+            return True
+        except Exception:
+            return False
+
+
+@pytest.mark.skipif(not _backend_available(), reason="No local LLM backend")
+def test_non_stream_generation():
+    p = OllamaProvider()
+    out = p.generate(system="You are a test bot", prompt="Say hello", max_tokens=32)
+    assert isinstance(out, str) and out.strip()
+    assert len(out.split()) <= settings.LLM_MAX_TOKENS + 50
+
+
+@pytest.mark.skipif(not _backend_available(), reason="No local LLM backend")
+def test_stream_generation():
+    p = OllamaProvider()
+    chunks = list(
+        p.generate(
+            system="You are a test bot",
+            prompt="Say hello",
+            max_tokens=32,
+            stream=True,
+        )
+    )
+    text = "".join(chunks)
+    assert text.strip()
+    assert len(text.split()) <= settings.LLM_MAX_TOKENS + 50
+
+
+@pytest.mark.skipif(not _backend_available(), reason="No local LLM backend")
+def test_seed_determinism(monkeypatch):
+    monkeypatch.setattr(settings, "LLM_SEED", 42)
+    p1 = OllamaProvider()
+    out1 = p1.generate(system="You are a test bot", prompt="Tell a joke", max_tokens=32)
+    p2 = OllamaProvider()
+    out2 = p2.generate(system="You are a test bot", prompt="Tell a joke", max_tokens=32)
+    assert out1 == out2
+
+
+@pytest.mark.skipif(not _backend_available(), reason="No local LLM backend")
+def test_stop_tokens():
+    p = OllamaProvider()
+    stop_token = "qqqSTOPzzz"
+    out = p.generate(
+        system="You are a test bot",
+        prompt="Say this should end",
+        max_tokens=32,
+        stop=[stop_token],
+    )
+    assert stop_token.lower() not in out.lower()


### PR DESCRIPTION
## Summary
- implement `OllamaProvider` supporting streaming, stop tokens, retries, and llama.cpp fallback
- expose provider via `PROVIDER_LLM=ollama` and add related settings
- add tests and dev script for local model setup

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a508d35f4c83328bd2d99269b8976f