### PR TITLE
feat: make ollama provider configurable

### DIFF
--- a/app/providers/ollama.py
+++ b/app/providers/ollama.py
@@ -22,9 +22,11 @@ DEFAULT_MODELS = [
 
 class OllamaProvider(LLMProvider):
     def __init__(self) -> None:
-        self.base_url = "http://127.0.0.1:11434"
+        self.base_url = settings.OLLAMA_URL.rstrip("/")
         self.lcpp_url = settings.LLAMACPP_SERVER_URL
-        self.client = httpx.Client(timeout=httpx.Timeout(30.0, read=600.0))
+        self.client = httpx.Client(
+            timeout=httpx.Timeout(connect=5.0, read=600.0, write=30.0, pool=None)
+        )
         self.ctx = settings.LLM_CTX
         self.max_tokens = settings.LLM_MAX_TOKENS
         self.temp = settings.LLM_TEMP

--- a/app/providers/ollama_embed.py
+++ b/app/providers/ollama_embed.py
@@ -22,8 +22,10 @@ DEFAULT_MODELS = [
 
 class OllamaEmbeddings(EmbeddingsProvider):
     def __init__(self) -> None:
-        self.base_url = "http://127.0.0.1:11434"
-        self.client = httpx.Client(timeout=httpx.Timeout(30.0, read=600.0))
+        self.base_url = settings.OLLAMA_URL.rstrip("/")
+        self.client = httpx.Client(
+            timeout=httpx.Timeout(connect=5.0, read=600.0, write=30.0, pool=None)
+        )
         self.model = settings.EMB_MODEL or self._select_model()
 
         if not self._ollama_available():

--- a/app/settings.py
+++ b/app/settings.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
     PROVIDER_CLOCK: str = "system"
 
     # Local LLM configuration
+    OLLAMA_URL: str = "http://127.0.0.1:11434"
     LLM_MODEL: str | None = None
     EMB_MODEL: str | None = None
     LLM_CTX: int = 8192

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -8,7 +8,7 @@ from app.settings import settings
 
 def _backend_available() -> bool:
     try:
-        httpx.get("http://127.0.0.1:11434/api/tags", timeout=1.0)
+        httpx.get(f"{settings.OLLAMA_URL.rstrip('/')}/api/tags", timeout=1.0)
         return True
     except Exception:
         url = settings.LLAMACPP_SERVER_URL or os.environ.get("LLAMACPP_SERVER_URL")


### PR DESCRIPTION
## Summary
- allow configuring Ollama server via `OLLAMA_URL`
- use extended httpx timeouts for Ollama LLM and embedding clients
- update provider tests to respect configured base URL

## Testing
- `pip install .[dev]`
- `PROVIDER_LLM=stub PROVIDER_EMBED=stub PYENV_VERSION=3.11.12 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b19b4b490c8332ba8822db9458a47a